### PR TITLE
Fix Preços

### DIFF
--- a/src/app/pages/inscricao/inscricao.component.ts
+++ b/src/app/pages/inscricao/inscricao.component.ts
@@ -5,7 +5,11 @@ import { Subject } from 'rxjs';
 import { AtividadesService } from '../../services/atividades.service';
 import { EdicaoSemanaService } from '../../services/edicaoSemana.service';
 import { AuthenticationService } from '../../services/authentication.service';
-import { Atividade, AtividadeLista } from '../../shared/models/atividades';
+import {
+  Atividade,
+  AtividadeLista,
+  TipoAtividadeEnum,
+} from '../../shared/models/atividades';
 import { InscricaoService } from '../../services/inscricao.service';
 import { AtividadeInscricao } from '../../shared/models/inscricao';
 import { ToastrService } from 'ngx-toastr';
@@ -130,8 +134,40 @@ export class InscricaoComponent implements OnInit {
         x.selecionada &&
         this.events.filter((z) => z.meta !== false).some((z) => z.id === x.id)
     ).length;
+
+    const descontoCurso = [0, 0, 15, 45, 75];
+
+    const totalAtividadesDict = this.atividades
+      .filter(
+        (x) =>
+          x.selecionada &&
+          this.events.filter((z) => z.meta !== false).some((z) => z.id === x.id)
+      )
+      .reduce(
+        (acc, x) => {
+          if (x.nome_tipo === TipoAtividadeEnum.CURSO) {
+            acc.curso++;
+          } else if (
+            x.nome_tipo === TipoAtividadeEnum.WORKSHOP ||
+            x.nome_tipo === TipoAtividadeEnum.VISITA_TECNICA
+          ) {
+            acc.workshopVisita++;
+          }
+          return acc;
+        },
+        { curso: 0, workshopVisita: 0 }
+      );
+
     this.valor = valorTotal ? valorTotal : 0;
-    this.descontoAcumulo = 5 * (totalAtividades - 1);
+    const acumuloDescontoCurso = descontoCurso[totalAtividadesDict.curso];
+    // this.descontoAcumulo = 5 * (totalAtividades - 1);
+    this.descontoAcumulo =
+      acumuloDescontoCurso +
+      (totalAtividadesDict.workshopVisita > 0
+        ? totalAtividadesDict.curso > 0
+          ? 10
+          : 0
+        : 0);
     this.haAtividades(false);
     this.refresh.next();
   }

--- a/src/app/shared/models/atividades.ts
+++ b/src/app/shared/models/atividades.ts
@@ -84,3 +84,10 @@ export type TipoAtividadeCod =
   | 'PALESTRA'
   | 'WORKSHOP'
   | 'VISITA_TECNICA';
+
+export enum TipoAtividadeEnum {
+  CURSO = 'Cursos',
+  PALESTRA = 'Palestras',
+  WORKSHOP = 'Workshops',
+  VISITA_TECNICA = 'Visitas Técnicas',
+}


### PR DESCRIPTION
Descrição

Implementa a lógica de cálculo de desconto acumulado com base no número de cursos e na presença de workshops/visitas técnicas.

Alterações principais

Criação de um dicionário totalAtividadesDict para contabilizar separadamente:

Cursos

Workshops + Visitas Técnicas (grupo único)

Definição de array descontoCurso para aplicar descontos progressivos conforme a quantidade de cursos.

Regra adicional:

Se houver ao menos 1 workshop/visita técnica e pelo menos 1 curso, adiciona +10 ao desconto acumulado.

Ajuste da atribuição de this.descontoAcumulo para refletir as novas regras.

Exemplo de cálculo

2 cursos → descontoCurso[2] = 15

2 cursos + 1 workshop → 15 + 10 = 25

Próximos passos / observações

Caso novas regras de desconto sejam criadas para palestras ou outros tipos de atividades, será necessário expandir o dicionário.